### PR TITLE
修复星标历史图链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ git -C "$env:USERPROFILE\scoop\buckets\main" remote set-url origin https://gh-pr
 <a href="https://github.com/Zacharia2"><img src="https://github.com/Zacharia2.png" width="50px;" alt="Zacharia2"/></a>
 
 
-![Star History Chart](https://api.star-history.com/svg?repos=duzyn/scoop-cn&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=duzyn/scoop-cn&type=Date)


### PR DESCRIPTION
README 中的星标历史图目前无法正常显示，因为图表服务受 GitHub 星标接口限制而失效。本修改将图表切换到新的域名，使其重新正常工作。